### PR TITLE
Añadimos role en generateToken

### DIFF
--- a/src/models/auth/signIn.model.js
+++ b/src/models/auth/signIn.model.js
@@ -33,6 +33,7 @@ export default async function signInModel(email, password) {
         id: user.user_id,
         username: user.username,
         email: user.email,
+        role:user.role,
       },
       JWT_SECRET,
       {

--- a/src/services/generateToken.js
+++ b/src/services/generateToken.js
@@ -4,3 +4,4 @@ export default function generateToken() {
     const token = crypto.randomBytes(15).toString('hex');
     return token
 }
+


### PR DESCRIPTION
Estamos probando los endpoints en Postman con Roberto, y hemos añadido role en el token, porque el token que teníamos no lo generaba, y aunque nos logueábamos como administrador nos saltaba el error de no tener permisos.